### PR TITLE
fix: return null for no string in parser

### DIFF
--- a/src/lib/utils/parser.ts
+++ b/src/lib/utils/parser.ts
@@ -10,6 +10,7 @@ export type ParseValue = {
 };
 
 export function parseString(str: string, value: ParseValue) {
+  if (!str) return null;
   str = str.replace(/\{link\}/gi, value.link).replace(/\{raw_link\}/gi, value.raw_link);
 
   const re = /\{(?<type>file|url|user)\.(?<prop>\w+)(::(?<mod>\w+))?\}/gi;


### PR DESCRIPTION
seems like this is often a problem, and was the case for previous versions